### PR TITLE
Migrate to List::SomeUtils

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -4,6 +4,8 @@ license = Perl_5
 copyright_holder = Matthew Phillips <mattp@cpan.org>
 version = 0.002011
 
+; authordep Pod::Weaver::Section::Contributors
+
 [@Basic]
 
 [Git::Contributors]

--- a/lib/Data/Perl/Role/Collection/Array.pm
+++ b/lib/Data/Perl/Role/Collection/Array.pm
@@ -6,7 +6,7 @@ use strictures 1;
 
 use Role::Tiny;
 use List::Util;
-use List::MoreUtils;
+use List::SomeUtils;
 use Scalar::Util qw/blessed/;
 
 sub new {
@@ -42,7 +42,7 @@ sub clear { @{$_[0]} = () }
 
 sub first { &List::Util::first($_[1], @{$_[0]}) }
 
-sub first_index { &List::MoreUtils::first_index($_[1], @{$_[0]}) }
+sub first_index { &List::SomeUtils::first_index($_[1], @{$_[0]}) }
 
 sub reduce { List::Util::reduce { $_[1]->($a, $b) } @{$_[0]} }
 
@@ -58,7 +58,7 @@ sub accessor {
 }
 
 sub natatime {
-  my $iter = List::MoreUtils::natatime($_[1], @{$_[0]});
+  my $iter = List::SomeUtils::natatime($_[1], @{$_[0]});
 
   if ($_[2]) {
     while (my @vals = $iter->()) {
@@ -135,7 +135,7 @@ sub shuffle {
 sub uniq {
   my ($self) = @_;
 
-  my @res = List::MoreUtils::uniq(@$self);
+  my @res = List::SomeUtils::uniq(@$self);
 
   blessed($self) ? blessed($self)->new(@res) : @res;
 }
@@ -328,7 +328,7 @@ This method requires a single argument.
 =item B<first_index( sub { ... } )>
 
 This method returns the index of the first matching item in the array, just
-like L<List::MoreUtils>'s C<first_index> function. The matching is done with a
+like L<List::SomeUtils>'s C<first_index> function. The matching is done with a
 subroutine reference you pass to this method. The subroutine will be called
 against each element in the array until one matches or all elements have been
 checked.
@@ -420,7 +420,7 @@ This method does not accept any arguments.
 =item B<uniq>
 
 Returns the array with all duplicate elements removed, like C<uniq> from
-L<List::MoreUtils>. The returned list is provided as a Collection::Array object.
+L<List::SomeUtils>. The returned list is provided as a Collection::Array object.
 
 This method does not accept any arguments.
 
@@ -508,7 +508,7 @@ This method accepts one or two arguments.
 =item B<natatime($n, $code)>
 
 This method returns an iterator which, on each call, returns C<$n> more items
-from the array, in order, like C<natatime> from L<List::MoreUtils>. A coderef
+from the array, in order, like C<natatime> from L<List::SomeUtils>. A coderef
 can optionally be provided; it will be called on each group of C<$n> elements
 in the array.
 


### PR DESCRIPTION
Please consider migrating to List::SomeUtils.

Rationale:

 - The install process for List::MoreUtils is now overly complicated using Conf::AutoConf

 - The License for List::MoreUtils was changed as of 0.417 (https://metacpan.org/pod/List::MoreUtils#COPYRIGHT-AND-LICENSE).  I am not a lawyer, but if Data::Perl can use dependency with the same license it is simpler for your users. My understanding is that the license was specifically changed to make it harder to merge fixes/features from MoreUtils into SomeUtils, which if true is weaponizing an open source license for ill.

I am personally motivated because Perl::Critic recently switched to using the SomeUtils version in git (and presumably a release will follow) (see discussion https://github.com/Perl-Critic/Perl-Critic/pull/909), and Data::Perl is the only remaining dependency for our app that uses List::MoreUtils.

Thank you for your consideration.

Normally would open a ticket before making a PR to gauge interest, but the change is easy enough and not much is lost by trying it out.

I've also include a change to dist.ini to add a development prereq, since Dist::Zilla failed for me without it.  I put that in a separate commit in case you want to use that without accepting the SomeUtils migration.